### PR TITLE
move functions to /autoload

### DIFF
--- a/autoload/textobj/lastpat.vim
+++ b/autoload/textobj/lastpat.vim
@@ -1,0 +1,26 @@
+function! textobj#lastpat#select_n()
+  return s:select(0)
+endfunction
+
+function! textobj#lastpat#select_N()
+  return s:select(1)
+endfunction
+
+function! s:select(opposite_p)
+  let forward_p = (v:searchforward && !a:opposite_p)
+  \               || (!v:searchforward && a:opposite_p)
+
+  if search(@/, 'ce' . (forward_p ? '' : 'b')) == 0
+    return 0
+  endif
+  let end_position = getpos('.')
+
+  if search(@/, 'bc') == 0
+    return 0
+  endif
+  let start_position = getpos('.')
+
+  return ['v', start_position, end_position]
+endfunction
+
+

--- a/plugin/textobj/lastpat.vim
+++ b/plugin/textobj/lastpat.vim
@@ -32,43 +32,13 @@ endif
 call textobj#user#plugin('lastpat', {
 \      'n': {
 \        'select': ['a/', 'i/'],
-\        '*select-function*': 's:select_n',
-\        '*sfile*': expand('<sfile>')
+\        '*select-function*': 'textobj#lastpat#select_n',
 \      },
 \      'N': {
 \        'select': ['a?', 'i?'],
-\        '*select-function*': 's:select_N',
-\        '*sfile*': expand('<sfile>')
+\        '*select-function*': 'textobj#lastpat#select_N',
 \      },
 \    })
-
-
-function! s:select_n()
-  return s:select(0)
-endfunction
-
-function! s:select_N()
-  return s:select(1)
-endfunction
-
-function! s:select(opposite_p)
-  let forward_p = (v:searchforward && !a:opposite_p)
-  \               || (!v:searchforward && a:opposite_p)
-
-  if search(@/, 'ce' . (forward_p ? '' : 'b')) == 0
-    return 0
-  endif
-  let end_position = getpos('.')
-
-  if search(@/, 'bc') == 0
-    return 0
-  endif
-  let start_position = getpos('.')
-
-  return ['v', start_position, end_position]
-endfunction
-
-
 
 
 let g:loaded_textobj_lastpat = 1


### PR DESCRIPTION
Script local functions are moved in textobj#lastpat namespace.
This change makes Vim start faster. (in my environment,  elapsed time
to load /plugin/lastpat.vim declines from 8.0 ms to 1.9 ms)
